### PR TITLE
Already registered username bug

### DIFF
--- a/FiftyBest/Pages/User.cshtml.cs
+++ b/FiftyBest/Pages/User.cshtml.cs
@@ -40,15 +40,18 @@ public class AuthNModel(IDataStore dataStore) : PageModel
     public async Task<IActionResult> OnPostChangeUsername(string userName, string new_userName)
     {
         var exists = await dataStore.UserExists(userName);
-        if (exists)
+        var exists_new = await dataStore.UserExists(new_userName);
+        var res_userName = userName;
+        if (exists && !exists_new)
         {
             await dataStore.UpdateUser(userName, new_userName);
+            res_userName = new_userName;
         }
 
         await HttpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
             new ClaimsPrincipal(
-                new ClaimsIdentity([new Claim(ClaimTypes.Name, new_userName)],
+                new ClaimsIdentity([new Claim(ClaimTypes.Name, res_userName)],
                 CookieAuthenticationDefaults.AuthenticationScheme)));
 
         return RedirectToPage();

--- a/FiftyBest/appsettings.json
+++ b/FiftyBest/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Restaurants": 
+    "Restaurants": ""
   },
   "Logging": {
     "LogLevel": {

--- a/FiftyBest/appsettings.json
+++ b/FiftyBest/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Restaurants": ""
+    "Restaurants": 
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Handles the bug, not the prettiest solution, simply just doesn't change the name if the new_username already exists. Didn't really think it was necessary to handle throwing error, just like Mark made a comment about, with the first login pr.